### PR TITLE
Simulation module

### DIFF
--- a/af2rave/simulation/reporter.py
+++ b/af2rave/simulation/reporter.py
@@ -63,7 +63,7 @@ class CVReporter(object):
 # The class can have any name but it must subclass MinimizationReporter.
 class MinimizationReporter(openmm.MinimizationReporter):
 
-    def __init__(self, maxIter: int = 100):
+    def __init__(self, maxIter: int = 500):
         super().__init__()
         self._maxIter = maxIter
         self._round = 1

--- a/af2rave/simulation/simulation.py
+++ b/af2rave/simulation/simulation.py
@@ -115,7 +115,7 @@ class UnbiasedSimulation():
 
         from .reporter import MinimizationReporter
         self.simulation.minimizeEnergy(
-            maxIterations=200, reporter=MinimizationReporter(200)
+            maxIterations=500, reporter=MinimizationReporter(500)
         )
         self.save_pdb(self._prefix + "_minimized.pdb")
         self.simulation.step(steps)


### PR DESCRIPTION
This PR addresses the following issues:

1. Bug Fix: Corrected the platform selection logic for systems without a GPU.
2. Enhancement: Added a minimization reporter.
3. Enhancement: Output a PDB file after optimization.

The optimization process in OpenMM is quite tricky. The gradient-based optimizer doesn’t handle constraints properly. The current workaround adds a harmonic bias to all constrained quantities and checks for violations after each epoch of minimizing the joint Hamiltonian. If the violation exceeds the integrator's tolerance, the spring constant is increased, and the process is repeated. If the violation worsens after tuning, the code returns and throws the game.

Without a `maxIteration` limit, this minimization could run forever in some cases. However, when a `maxIteration` is set, the final violation can be influenced by randomness, causing early termination. There's no perfect balance between the two, so I’ve set `maxIteration` to 500 and added a reporter to log the violation. If the minimization ends with a large violation, the simulation may crash, but at least users will be able to understand what went wrong from the output.