### PR TITLE
Transition to `pip`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,11 @@ build:
   jobs:
     post_create_environment:
       - pip install sphinx_rtd_theme
-  
+
+python:
+  install:
+    - path: .
+
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,13 +6,12 @@ version: 2
 
 build:
   os: ubuntu-24.04
-  tools:
-    python: "3.12"
   jobs:
     post_create_environment:
       - pip install sphinx_rtd_theme
 
 python:
+  version: "3.12"
   install:
     - path: .
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,16 +4,12 @@
 # Required
 version: 2
 
-conda:
-  environment: environment.yml
-
 build:
   os: ubuntu-24.04
   tools:
-    python: "mambaforge-latest"
+    python: "3.12"
   jobs:
     post_create_environment:
-      - echo "Preparing environment"
       - pip install sphinx_rtd_theme
   
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,12 +6,13 @@ version: 2
 
 build:
   os: ubuntu-24.04
+  tools:
+    python: "3.12"
   jobs:
     post_create_environment:
       - pip install sphinx_rtd_theme
 
 python:
-  version: "3.12"
   install:
     - path: .
 

--- a/README.rst
+++ b/README.rst
@@ -18,27 +18,14 @@ AlphaFold2-RAVE package generates boltzman-ranked non-native conformations for p
 Installation
 ----------------
 
-It is strongly recommended a separate environment for this package. 
-The ``environment.yml`` will take care of most of the dependencies.
-If you choose to install the dependencies this way, ColabFold will be selected as the default AlphaFold2 model.
-
-First, make sure you have your ssh-key to GitHub correctly setup, or use the https link to clone the repository.
-Either ``conda`` or ``mamba`` (recommended) is required. The code schnippet uses conda but feel free to use mamba.
+It is strongly recommended a separate environment for this package, either with ``conda`` or ``venv``. 
+After activating the environment, simply run:
 
 .. code-block:: bash
 
-    git clone git@github.com:tiwarylab/af2rave.git af2rave
-    cd af2rave
-    conda env create -n af2rave -f environment.yml
-    conda activate af2rave 
+    pip install git+https://github.com/tiwarylab/af2rave.git
 
-Then use ``pip`` to install the package.
-
-.. code-block:: bash
-
-    pip install .
-
-If you want the folding module installed. You need to install ColabFold with ``conda`` and download its parameters.
+If you want the folding module installed, too. You need to install ColabFold separately. One way to do it is with ``conda`` and download its parameters.
 
 .. code-block:: bash
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -5,27 +5,14 @@ Overview
 Installation
 ----------------
 
-It is strongly recommended a separate environment for this package. 
-The ``environment.yml`` will take care of most of the dependencies.
-If you choose to install the dependencies this way, ColabFold will be selected as the default AlphaFold2 model.
-
-First, make sure you have your ssh-key to GitHub correctly setup, or use the https link to clone the repository.
-Either ``conda`` or ``mamba`` (recommended) is required. The code schnippet uses conda but feel free to use mamba.
+It is strongly recommended a separate environment for this package, either with ``conda`` or ``venv``. 
+After activating the environment, simply run:
 
 .. code-block:: bash
 
-    git clone git@github.com:tiwarylab/af2rave.git af2rave
-    cd af2rave
-    conda env create -n af2rave -f environment.yml
-    conda activate af2rave 
+    pip install git+https://github.com/tiwarylab/af2rave.git
 
-Then use ``pip`` to install the package.
-
-.. code-block:: bash
-
-    pip install .
-
-If you want the folding module installed. You need to install ColabFold with ``conda`` and download its parameters.
+If you want the folding module installed, too. You need to install ColabFold separately. One way to do it is with ``conda`` and download its parameters.
 
 .. code-block:: bash
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,5 @@ channels:
   - bioconda
 dependencies:
   - python==3.11
-  - pytorch::pytorch
   - openmm>=8
-  - pdbfixer
-  - mdtraj
-  - numpy<2
-  - scikit-learn
   - typer
-  - numba
-  - natsort

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-dependencies:
-  - python==3.11
-  - openmm>=8
-  - typer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,15 @@ classifiers = [
 license = {text = "MIT license"}
 requires-python = ">= 3.10"
 dependencies = [
-  "natsort"
+  "natsort",
+  "mdtraj",
+  "numpy<2",
+  "openmm[cuda12]",
+  "pdbfixer @ git+https://github.com/openmm/pdbfixer.git",
+  "torch",
+  "scikit-learn",
+  "openmm",
+  "typer"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`pip install af2rave` was once proposed but due to limits with OpenMM this was once not possible. Now with OpenMM 8.2.0 their distribution on pip come with CUDA platforms so this is the time we can move to pip as well.