### PR TITLE
Fix regular space clustering comparing points to wrong coordinates

### DIFF
--- a/af2rave/feature/analysis.py
+++ b/af2rave/feature/analysis.py
@@ -559,7 +559,7 @@ class FeatureSelection:
 
         while i < npoints:
             x_active = data[i:i + batch_size]
-            current_centers = data[center_id[center_id != -1]]
+            current_centers = z[center_id[center_id != -1]]
 
             # Compute Euclidean distances normalized by sqrt(ndim)
             distances = np.linalg.norm(x_active[:, np.newaxis, :] - current_centers[np.newaxis, :, :], axis=2) / np.sqrt(ndim)


### PR DESCRIPTION
## Problem

In `FeatureSelection.regular_space_clustering`, `center_id` stores **original** indices into the feature array `z`. The data is shuffled once up front:

```python
data = z[perm]            # data[k] == z[perm[k]]
center_id[0] = perm[0]    # center_id holds original indices
```

but the per-batch distance comparison indexed the **permuted** array with those original indices:

```python
current_centers = data[center_id[center_id != -1]]   # == z[perm[center_id]]  ✗
```

Since `perm` is a non-trivial permutation, `data[center_id] != z[center_id]`, so every center after the reference was compared against the **wrong** coordinates. The `min_dist` separation guarantee was silently violated, and the resulting centers depended on the random permutation — a likely source of the non-reproducible clustering.

## Fix

Index the original array so distances use the true center coordinates:

```python
current_centers = z[center_id[center_id != -1]]
```

One-line change; `center_id` (returned) semantics are unchanged.

## Verification

On synthetic data (500 points, 8 dims, `min_dist = 0.5`, normalized by `sqrt(ndim)`), checking the minimum pairwise separation of the selected centers:

| Version | Min center separation | Respects `min_dist`? |
|---|---|---|
| Before (`data[...]`) | 0.379 | ❌ |
| After (`z[...]`)     | 0.503 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)